### PR TITLE
feat(infra): add VPC module with public/private subnets, IGW, NAT gateway, and routing

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -20,3 +20,20 @@ terraform {
 provider "aws" {
   region = "us-east-1"
 }
+
+module "vpc" {
+  source = "../../modules/vpc"
+
+  vpc_cidr            = "10.0.0.0/16"
+  public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24"]
+  private_subnet_cidrs = [
+    "10.0.2.0/24",
+    "10.0.3.0/24",
+  ]
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "dev"
+  }
+
+}

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     aws = {
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "cloudpulse-tf-state"
-    key            = "envs/prod/terraform.tfstate"
-    region         = "us-east-1"
-    encrypt        = true
-    use_lockfile   = true
+    bucket       = "cloudpulse-tf-state"
+    key          = "envs/prod/terraform.tfstate"
+    region       = "us-east-1"
+    encrypt      = true
+    use_lockfile = true
   }
 }
 
@@ -21,3 +21,18 @@ provider "aws" {
   region = "us-east-1"
 }
 
+module "vpc" {
+  source = "../../modules/vpc"
+
+  vpc_cidr            = "10.0.0.0/16"
+  public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24"]
+  private_subnet_cidrs = [
+    "10.0.2.0/24",
+    "10.0.3.0/24",
+  ]
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "prod"
+  }
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,153 @@
+// VPC module: creates a VPC with public + private subnets, IGW, NAT gateway, and route tables.
+
+data "aws_availability_zones" "this" {
+  state = "available"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-vpc"
+    }
+  )
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-igw"
+    }
+  )
+}
+
+// public subnets (for ALB, NAT gateway, etc.)
+resource "aws_subnet" "public" {
+  for_each = {
+    for idx, cidr in var.public_subnet_cidrs :
+    idx => {
+      cidr = cidr
+      az   = data.aws_availability_zones.this.names[idx]
+    }
+  }
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-public-${each.key}"
+      Tier = "public"
+    }
+  )
+}
+
+// private subnets (for ECS tasks, DBs, etc.)
+resource "aws_subnet" "private" {
+  for_each = {
+    for idx, cidr in var.private_subnet_cidrs :
+    idx => {
+      cidr = cidr
+      az   = data.aws_availability_zones.this.names[idx]
+    }
+  }
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = each.value.cidr
+  availability_zone = each.value.az
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-private-${each.key}"
+      Tier = "private"
+    }
+  )
+}
+
+// allocate EIP for the NAT gateway in the first public subnet
+resource "aws_eip" "nat" {
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-nat-eip"
+    }
+  )
+}
+
+// NAT gateway lives in the first public subnet
+locals {
+  first_public_subnet_id = element(values(aws_subnet.public)[*].id, 0)
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = local.first_public_subnet_id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-nat-gateway"
+    }
+  )
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+// public route table (0.0.0.0/0 → IGW)
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-public-rt"
+    }
+  )
+}
+
+// associate all public subnets with the public route table
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+// private route table (0.0.0.0/0 → NAT)
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "cloudpulse-private-rt"
+    }
+  )
+}
+
+// associate all private subnets with the private route table
+resource "aws_route_table_association" "private" {
+  for_each       = aws_subnet.private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = [for s in aws_subnet.private : s.id]
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,23 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for the public subnets"
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the private subnets"
+  type        = list(string)
+  default     = ["10.0.2.0/24", "10.0.3.0/24"]
+}
+
+variable "tags" {
+  description = "Base tags to apply to all VPC resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Title
- feat(infra): add VPC module with public/private subnets, IGW, NAT gateway, and routing

This PR introduces the foundational VPC infrastructure for CloudPulse, providing a production-grade network topology that future ECS, API Gateway, Lambda, and runner components will depend on.

## What’s in this PR?
- Created dedicated VPC module (CIDR 10.0.0.0/16)
- Added two public and two private subnets across AZs
- Added Internet Gateway and Elastic IP + NAT Gateway
- Added public and private route tables + associations
- Wired module into dev and prod environments
- Updated tagging and module outputs

### Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (README/ADRs/runbooks)
- [x] infra (Terraform/VPC/ECS/IAM)
- [ ] perf (latency/throughput/memory)
- [ ] refactor (no behavior change)
- [ ] chore (build, deps, CI)

### Scope
- [ ] app/api
- [ ] app/runner
- [x] infra/terraform
- [ ] observability (metrics/logs/alarms)
- [ ] docs (README/Timeline/ADRs)
- [ ] ci (GitHub Actions)


## Tests & Verification
terraform init, plan, and apply succeeded in dev
Verified all resources in AWS Console:
- VPC
- Subnets in correct AZs
- IGW, NAT, and EIP
- Route tables + associations

## Notes
This VPC establishes the core network-layer building blocks required for the CloudPulse platform. It enables:
- Secure ECS Fargate deployments
- Private API runtime environments
- Public load balancer integration
- NAT-based outbound access for internal services
- Multi-AZ high availability

This is now the networking foundation for all subsequent CloudPulse components.

