### PR TITLE
feat(infra): introduce ECR repo and ECS API wiring (apply-optional)

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -21,6 +21,28 @@ provider "aws" {
   region = "us-east-1"
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_ecr_repository" "api" {
+  name = "cloudpulse-api"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "dev"
+  }
+}
+
+locals {
+  api_image = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${aws_ecr_repository.api.name}:dev"
+}
+
+
 module "vpc" {
   source = "../../modules/vpc"
 
@@ -37,3 +59,22 @@ module "vpc" {
   }
 
 }
+
+module "ecs_api" {
+  source = "../../modules/ecs_api"
+
+  vpc_id             = module.vpc.vpc_id
+  public_subnet_ids  = module.vpc.public_subnet_ids
+  private_subnet_ids = module.vpc.private_subnet_ids
+
+  container_image = local.api_image
+  container_port  = 8080
+  desired_count   = 1
+  region          = data.aws_region.current.name
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "dev"
+  }
+}
+

--- a/infra/modules/ecs_api/main.tf
+++ b/infra/modules/ecs_api/main.tf
@@ -1,0 +1,265 @@
+locals {
+  name_prefix = "cloudpulse-api"
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "${local.name_prefix}-cluster"
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-cluster"
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 14
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-logs"
+    }
+  )
+}
+
+// Security group for the ALB: allow HTTP from anywhere
+resource "aws_security_group" "alb" {
+  name        = "${local.name_prefix}-alb-sg"
+  description = "ALB security group for CloudPulse API"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP from the internet"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-alb-sg"
+    }
+  )
+}
+
+// Security group for ECS tasks: only ALB can talk to the tasks
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${local.name_prefix}-ecs-sg"
+  description = "ECS tasks security group for CloudPulse API"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Traffic from ALB"
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    security_groups = [
+      aws_security_group.alb.id
+    ]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-ecs-sg"
+    }
+  )
+}
+
+// Application Load Balancer
+resource "aws_lb" "this" {
+  name               = "${local.name_prefix}-alb"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-alb"
+    }
+  )
+}
+
+// Target group for ECS tasks
+resource "aws_lb_target_group" "this" {
+  name        = "${local.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    path                = "/health"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 15
+    matcher             = "200"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-tg"
+    }
+  )
+}
+
+// Listener on port 80 forwarding to the target group
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+// IAM roles for ECS task execution and task role
+data "aws_iam_policy_document" "ecs_task_execution_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = "${local.name_prefix}-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume_role.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-execution-role"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+// Task role (for app-level permissions; currently empty)
+resource "aws_iam_role" "ecs_task" {
+  name               = "${local.name_prefix}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_assume_role.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-task-role"
+    }
+  )
+}
+
+// ECS Task Definition
+resource "aws_ecs_task_definition" "this" {
+  family                   = "${local.name_prefix}-task"
+  cpu                      = "256"
+  memory                   = "512"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "cloudpulse-api"
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        {
+          name  = "PORT"
+          value = tostring(var.container_port)
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-task-def"
+    }
+  )
+}
+
+// ECS Service
+resource "aws_ecs_service" "this" {
+  name            = "${local.name_prefix}-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "cloudpulse-api"
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  depends_on = [
+    aws_lb_listener.http,
+  ]
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-service"
+    }
+  )
+}

--- a/infra/modules/ecs_api/outputs.tf
+++ b/infra/modules/ecs_api/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer"
+  value       = aws_lb.this.dns_name
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecs_service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.this.name
+}

--- a/infra/modules/ecs_api/variables.tf
+++ b/infra/modules/ecs_api/variables.tf
@@ -1,0 +1,43 @@
+variable "vpc_id" {
+  description = "ID of the VPC where ECS and ALB will run"
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "List of public subnet IDs for the ALB"
+  type        = list(string)
+}
+
+variable "private_subnet_ids" {
+  description = "List of private subnet IDs for ECS tasks"
+  type        = list(string)
+}
+
+variable "container_image" {
+  description = "Container image URI for the CloudPulse API"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the API container listens on"
+  type        = number
+  default     = 8080
+}
+
+variable "desired_count" {
+  description = "Desired number of ECS tasks"
+  type        = number
+  default     = 2
+}
+
+variable "region" {
+  description = "AWS region (used for logs)"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "tags" {
+  description = "Base tags to apply to ECS and ALB resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
This PR introduces the ECR repository and ECS API wiring needed for CloudPulse's infrastructure, while intentionally keeping the ECS/ALB deployment **apply-optional** to avoid unnecessary AWS runtime costs during development. With this in place, the environment is ready for automated builds, image pushes, and eventual deployment to ECS Fargate.


## What’s in this PR?
### ECR Repository
- Added `aws_ecr_repository.api` to host `cloudpulse-api` container images.
- Enabled scan-on-push to support future security workflows.

### Dynamic Image URI Generation
- Added `data "aws_caller_identity"` and `data "aws_region"` to compute account + region.
- Introduced `local.api_image`: <account-id>.dkr.ecr.<region>.amazonaws.com/cloudpulse-api:dev

### ECS API Module Wiring (dev only)
- Connected the `ecs_api` module to:
  - VPC ID
  - Public and private subnet IDs
  - Image URI from `local.api_image`
  - Set `desired_count = 1` to control costs if applied.
- No changes applied beyond the ECR repo.


### Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (README/ADRs/runbooks)
- [x] infra (Terraform/VPC/ECS/IAM)
- [ ] perf (latency/throughput/memory)
- [ ] refactor (no behavior change)
- [ ] chore (build, deps, CI)

### Scope
- [x] app/api
- [ ] app/runner
- [x] infra/terraform
- [ ] observability (metrics/logs/alarms)
- [ ] docs (README/Timeline/ADRs)
- [ ] ci (GitHub Actions)


## Tests & Verification
- Verified through AWS console

## Notes
## How to Push a Dev Image (Optional)
```bash
aws ecr get-login-password --region us-east-1 \
| docker login --username AWS --password-stdin <account-id>.dkr.ecr.us-east-1.amazonaws.com

docker build -t cloudpulse-api:dev -f deployments/docker/Dockerfile.api .
docker tag cloudpulse-api:dev <account-id>.dkr.ecr.us-east-1.amazonaws.com/cloudpulse-api:dev
docker push <account-id>.dkr.ecr.us-east-1.amazonaws.com/cloudpulse-api:dev

