### PR TITLE
feat(infra): add DynamoDB probe results table for dev/prod

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -78,3 +78,15 @@ module "ecs_api" {
   }
 }
 
+module "results_table" {
+  source = "../../modules/dynamodb_results"
+
+  table_name_prefix = "cloudpulse-probe-results"
+  env               = "dev"
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "dev"
+  }
+}
+

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -36,3 +36,16 @@ module "vpc" {
     Env     = "prod"
   }
 }
+
+module "results_table" {
+  source = "../../modules/dynamodb_results"
+
+  table_name_prefix = "cloudpulse-probe-results"
+  env               = "prod"
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "prod"
+  }
+}
+

--- a/infra/modules/dynamodb_results/main.tf
+++ b/infra/modules/dynamodb_results/main.tf
@@ -1,0 +1,39 @@
+locals {
+  table_name = "${var.table_name_prefix}-${var.env}"
+}
+
+// DynamoDB table to store probe results for CloudPulse.
+// Key design:
+// - Partition key: target_id (String)
+// - Sort key: timestamp (Number, epoch millis)
+// This supports efficient per-target time-series queries.
+resource "aws_dynamodb_table" "results" {
+  name         = local.table_name
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key  = "target_id"
+  range_key = "timestamp"
+
+  attribute {
+    name = "target_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "timestamp"
+    type = "N"
+  }
+
+  // Time-to-live for automatic expiry of old results.
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = local.table_name
+    }
+  )
+}

--- a/infra/modules/dynamodb_results/outputs.tf
+++ b/infra/modules/dynamodb_results/outputs.tf
@@ -1,0 +1,9 @@
+output "table_name" {
+  description = "Name of the DynamoDB results table"
+  value       = aws_dynamodb_table.results.name
+}
+
+output "table_arn" {
+  description = "ARN of the DynamoDB results table"
+  value       = aws_dynamodb_table.results.arn
+}

--- a/infra/modules/dynamodb_results/variables.tf
+++ b/infra/modules/dynamodb_results/variables.tf
@@ -1,0 +1,15 @@
+variable "table_name_prefix" {
+  description = "Base prefix for the DynamoDB table name (e.g., cloudpulse-probe-results)"
+  type        = string
+}
+
+variable "env" {
+  description = "Environment name (e.g., dev, prod)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to the DynamoDB table"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Title
- feat(infra): add DynamoDB probe results table for dev/prod


## What’s in this PR?
- Added infra/modules/dynamodb_results:
  - PAY_PER_REQUEST DynamoDB table for probe results
  - target_id (S) + timestamp (N) key schema
  - TTL on ttl attribute for automatic expiry
- Wired module into infra/envs/dev and infra/envs/prod:
  - Table names: cloudpulse-probe-results-dev and cloudpulse-probe-results-prod
  - No application changes yet; runner + API integration will follow in separate milestones.

### Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (README/ADRs/runbooks)
- [x] infra (Terraform/VPC/ECS/IAM)
- [ ] perf (latency/throughput/memory)
- [ ] refactor (no behavior change)
- [ ] chore (build, deps, CI)

### Scope
- [x] app/api
- [ ] app/runner
- [x] infra/terraform
- [ ] observability (metrics/logs/alarms)
- [ ] docs (README/Timeline/ADRs)
- [ ] ci (GitHub Actions)


## Tests & Verification
- [ ] Unit tests (`go test ./...`) added/updated
- [ ] Local run verified:

## Notes
-

