### PR TITLE
feat(infra): introduce EventBridge-scheduled Lambda runner module

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -90,3 +90,19 @@ module "results_table" {
   }
 }
 
+module "runner" {
+  source = "../../modules/runner"
+
+  env                 = "dev"
+  schedule_expression = "rate(1 minute)"
+
+  // TODO: point this at a real ECR image once the runner container exists.
+  runner_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/cloudpulse-runner:dev"
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "dev"
+  }
+}
+
+

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -49,3 +49,18 @@ module "results_table" {
   }
 }
 
+module "runner" {
+  source = "../../modules/runner"
+
+  env                 = "prod"
+  schedule_expression = "rate(5 minutes)"
+
+  runner_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/cloudpulse-runner:prod"
+
+  tags = {
+    Project = "cloudpulse"
+    Env     = "prod"
+  }
+}
+
+

--- a/infra/modules/runner/main.tf
+++ b/infra/modules/runner/main.tf
@@ -1,0 +1,88 @@
+locals {
+  name_prefix = "cloudpulse-runner-${var.env}"
+}
+
+// IAM assume-role policy for Lambda
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+// Basic execution role (logs, etc.)
+resource "aws_iam_role" "lambda_role" {
+  name               = "${local.name_prefix}-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-role"
+    }
+  )
+}
+
+// Attach AWS-managed policy for basic Lambda execution (CloudWatch logs)
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+// Runner Lambda function (stub for now, using container image)
+resource "aws_lambda_function" "runner" {
+  function_name = local.name_prefix
+  role          = aws_iam_role.lambda_role.arn
+
+  package_type = "Image"
+  image_uri    = var.runner_image
+
+  timeout     = 30
+  memory_size = 256
+
+  environment {
+    variables = {
+      ENV = var.env
+    }
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = local.name_prefix
+    }
+  )
+}
+
+// EventBridge rule that triggers the runner on a schedule
+resource "aws_cloudwatch_event_rule" "schedule" {
+  name                = "${local.name_prefix}-schedule"
+  schedule_expression = var.schedule_expression
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${local.name_prefix}-schedule"
+    }
+  )
+}
+
+// EventBridge target: invoke the Lambda
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule      = aws_cloudwatch_event_rule.schedule.name
+  target_id = "${local.name_prefix}-target"
+  arn       = aws_lambda_function.runner.arn
+}
+
+// Allow EventBridge to invoke the Lambda
+resource "aws_lambda_permission" "allow_events" {
+  statement_id  = "AllowExecutionFromEventBridge-${var.env}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.runner.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.schedule.arn
+}

--- a/infra/modules/runner/outputs.tf
+++ b/infra/modules/runner/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_name" {
+  description = "Name of the runner Lambda function"
+  value       = aws_lambda_function.runner.function_name
+}
+
+output "schedule_rule_arn" {
+  description = "ARN of the EventBridge schedule rule"
+  value       = aws_cloudwatch_event_rule.schedule.arn
+}

--- a/infra/modules/runner/variables.tf
+++ b/infra/modules/runner/variables.tf
@@ -1,0 +1,21 @@
+variable "env" {
+  description = "Environment name (e.g., dev, prod)"
+  type        = string
+}
+
+variable "runner_image" {
+  description = "Container image URI for the runner Lambda (package_type=Image)"
+  type        = string
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule expression, e.g. rate(1 minute)"
+  type        = string
+  default     = "rate(1 minute)"
+}
+
+variable "tags" {
+  description = "Base tags to apply to runner resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

This PR introduces the infrastructure for the CloudPulse **runner**, which will eventually execute periodic uptime probes. For now, this milestone adds the Lambda + EventBridge scheduling infrastructure, keeping the function body and ECR image stubbed out. The infrastructure is fully defined but apply-optional, similar to the previous ECS milestone, preventing unnecessary cost during early development.


## What’s in this PR?
New `runner` Terraform module
A reusable module located at `infra/modules/runner` that provisions:
- **Lambda function (package_type = Image)**
  - Placeholder container image URI
  - Basic environment variables (currently only `ENV`)
  - 256 MB memory, 30s timeout
- **IAM role + AWS-managed basic Lambda execution policy**
  - Allows writing to CloudWatch logs
- **EventBridge schedule rule**
  - Uses `rate(1 minute)` in dev (configurable)
  - Uses `rate(5 minutes)` in prod (configurable)
- **EventBridge → Lambda target + lambda:Invoke permission**
  - Ensures the scheduler can invoke the function

Wired into both environments

### Dev (`infra/envs/dev`)
- Schedule: `rate(1 minute)`
- Placeholder image: `cloudpulse-runner:dev`

### Prod (`infra/envs/prod`)
- Schedule: `rate(5 minutes)`
- Placeholder image: `cloudpulse-runner:prod`

This milestone prepares the platform for real probe execution:
- The runner will eventually check registered endpoints.
- The runner will write probe results to the DynamoDB table added in the previous milestone.
- The API will later expose this data for dashboards and metrics.

### Type
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (README/ADRs/runbooks)
- [x] infra (Terraform/VPC/ECS/IAM)
- [ ] perf (latency/throughput/memory)
- [ ] refactor (no behavior change)
- [ ] chore (build, deps, CI)

### Scope
- [x] app/api
- [ ] app/runner
- [x] infra/terraform
- [ ] observability (metrics/logs/alarms)
- [ ] docs (README/Timeline/ADRs)
- [ ] ci (GitHub Actions)


## Tests & Verification
- [ ] Unit tests (`go test ./...`) added/updated
- [ ] Local run verified:

## Notes
-

