### PR TITLE
ci: introduce GitHub Actions pipeline for Go, Terraform, and Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    go-tests:
+        name: Go tests & vet
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: "1.22"
+
+            - name: Download Go modules
+              run: go mod download
+
+            - name: Run Go tests
+              run: go test ./...
+
+            - name: Run go vet
+              run: go vet ./...
+
+    terraform-checks:
+        name: Terraform fmt & validate
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up Terraform
+              uses: hashicorp/setup-terraform@v3
+              with:
+                  terraform_version: 1.11.0
+
+            - name: Terraform fmt (recursive)
+              run: terraform fmt -check -recursive
+
+            - name: Terraform validate (dev)
+              working-directory: infra/envs/dev
+              run: |
+                  terraform init -backend=false
+                  terraform validate
+
+            - name: Terraform validate (prod)
+              working-directory: infra/envs/prod
+              run: |
+                  terraform init -backend=false
+                  terraform validate
+
+    docker-api-build:
+        name: Build API Docker image
+        runs-on: ubuntu-latest
+        needs: go-tests
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Build cloudpulse-api image
+              run: docker build -t cloudpulse-api:ci -f deployments/docker/Dockerfile.api .


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions CI workflow for CloudPulse. The workflow runs Go tests, validates Terraform, and builds the `cloudpulse-api` Docker image on every push to `main` and for all pull requests. This gives fast feedback on code quality and keeps the project looking production-ready for reviewers and hiring managers.


## What’s in this PR?
### `.github/workflows/ci.yml`

**Jobs:**

1. **go-tests**
   - Uses `actions/setup-go` with Go `1.22`
   - Runs:
     - `go mod download`
     - `go test ./...`
     - `go vet ./...`

2. **terraform-checks**
   - Uses `hashicorp/setup-terraform` with Terraform `1.11.0`
   - Runs:
     - `terraform fmt -check -recursive`
     - `terraform init -backend=false` and `terraform validate` in:
       - `infra/envs/dev`
       - `infra/envs/prod`
   - Backend is disabled during validation so CI doesn’t require AWS credentials or touch remote state.

3. **docker-api-build**
   - Builds the CloudPulse API container image:
     - `docker build -t cloudpulse-api:ci -f deployments/docker/Dockerfile.api .`
   - Ensures the Dockerfile remains valid and reproducible.


### Type
- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (README/ADRs/runbooks)
- [ ] infra (Terraform/VPC/ECS/IAM)
- [ ] perf (latency/throughput/memory)
- [ ] refactor (no behavior change)
- [x] chore (build, deps, CI)

### Scope
- [ ] app/api
- [ ] app/runner
- [ ] infra/terraform
- [ ] observability (metrics/logs/alarms)
- [ ] docs (README/Timeline/ADRs)
- [x] ci (GitHub Actions)


## Tests & Verification
- [ ] Unit tests (`go test ./...`) added/updated
- [ ] Local run verified:

## Notes
- This PR is intentionally CI-only. No AWS resources are created or modified by this workflow.


