### PR TITLE
feat(helm): add Helm chart for cloudpulse-api deployment

### DIFF
--- a/deployments/helm/cloudpulse-api/.helmignore
+++ b/deployments/helm/cloudpulse-api/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/helm/cloudpulse-api/Chart.yaml
+++ b/deployments/helm/cloudpulse-api/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: cloudpulse-api
+description: Helm chart for the CloudPulse API
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/deployments/helm/cloudpulse-api/templates/NOTES.txt
+++ b/deployments/helm/cloudpulse-api/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cloudpulse-api.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "cloudpulse-api.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "cloudpulse-api.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cloudpulse-api.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deployments/helm/cloudpulse-api/templates/_helpers.tpl
+++ b/deployments/helm/cloudpulse-api/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* Helper template for cloudpulse-api chart */}}
+{{- define "cloudpulse-api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/* Helper template to create a fullname for resources */}}
+{{- define "cloudpulse-api.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "cloudpulse-api.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/* Helper template for common labels */}}
+{{- define "cloudpulse-api.labels" -}}
+app.kubernetes.io/name: {{ include "cloudpulse-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: cloudpulse
+{{- end }}
+
+{{/* Helper template for selector labels */}}
+{{- define "cloudpulse-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudpulse-api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deployments/helm/cloudpulse-api/templates/deployment.yaml
+++ b/deployments/helm/cloudpulse-api/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudpulse-api.fullname" . }}
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cloudpulse-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cloudpulse-api.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deployments/helm/cloudpulse-api/templates/hpa.yaml
+++ b/deployments/helm/cloudpulse-api/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cloudpulse-api.fullname" . }}
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cloudpulse-api.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployments/helm/cloudpulse-api/templates/ingress.yaml
+++ b/deployments/helm/cloudpulse-api/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cloudpulse-api.fullname" . }}
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "cloudpulse-api.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployments/helm/cloudpulse-api/templates/service.yaml
+++ b/deployments/helm/cloudpulse-api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudpulse-api.fullname" . }}
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "cloudpulse-api.selectorLabels" . | nindent 4 }}

--- a/deployments/helm/cloudpulse-api/templates/serviceaccount.yaml
+++ b/deployments/helm/cloudpulse-api/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cloudpulse-api.serviceAccountName" . }}
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/deployments/helm/cloudpulse-api/templates/tests/test-connection.yaml
+++ b/deployments/helm/cloudpulse-api/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cloudpulse-api.fullname" . }}-test-connection"
+  labels:
+    {{- include "cloudpulse-api.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "cloudpulse-api.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deployments/helm/cloudpulse-api/values.yaml
+++ b/deployments/helm/cloudpulse-api/values.yaml
@@ -1,0 +1,83 @@
+# Default values for cloudpulse-api.
+# Declare variables to be passed into your templates.
+
+# Number of API replicas
+replicaCount: 2
+
+# Container image settings
+image:
+  repository: cloudpulse-api
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: dev
+
+# Optional image pull secrets for private registries
+imagePullSecrets: []
+# - name: my-registry-secret
+
+# Optional extra labels/annotations
+podAnnotations: {}
+podLabels: {}
+
+# Service account configuration 
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+# Horizontal Pod Autoscaler configuration
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: null
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 80
+
+# Container port the API listens on
+containerPort: 8080
+
+# Probes
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 20
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+# Resource requests/limits
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+
+# Advanced scheduling knobs (not used yet, but available)
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Name overrides (optional)
+nameOverride: ""
+fullnameOverride: cloudpulse-api

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,3 +21,7 @@
 	- Create a pipe directly to a pod:
 		- kubectl port-forward pod/cloudpulse-api-xxxxx 8080:8080
 
+- Clean out old manually-applied Deployment/service
+	- kubectl -n cloudpulse delete deploy cloudpulse-api
+	- kubectl -n cloudpulse delete svc cloudpulse-api
+


### PR DESCRIPTION
## Summary
This PR introduces a fully working Helm chart for deploying the CloudPulse API to Kubernetes.
It replaces the previous raw YAML manifests with a templated, configurable, Helm-managed deployment and adds documentation for running CloudPulse using Helm.

This is now the recommended way to run CloudPulse locally (Rancher Desktop, kind, etc.) and will serve as the foundation for future multi-environment deployments, CI/CD automation, and additional CloudPulse components (runner, scheduler, DynamoDB integration, etc.).

## What’s in this PR?

### New Helm Chart
Located under: deployments/helm/cloudpulse-api/
Includes:
- chart.yaml – chart metadata
- values.yaml – configurable image, replicas, probes, resources, ports, service settings, etc.
- templates/deployment.yaml – fully templated Deployment matching the app’s actual config
- templates/service.yaml – ClusterIP service wired to the Deployment via selector labels
- templates/_helpers.tpl – Helm-standard naming and label helpers

## Testing Performed

Successfully passed helm lint on the chart
Ran helm template to verify correctly rendered YAML
Installed via: helm upgrade --install cloudpulse-api deployments/helm/cloudpulse-api -n cloudpulse

Verified:
- Deployment: replicas running with correct image + probes
- Service: correct ports and selectors
- Pods: Running + READY 1/1
- Port-forward test confirmed:
- curl http://localhost:8080/health
  - → ok
 
Everything now deploys cleanly and runs fully under Helm control.

