### PR TITLE
Local Kubernetes Support & API Enhancements

### DIFF
--- a/apps/api/handlers.go
+++ b/apps/api/handlers.go
@@ -68,6 +68,7 @@ func targetsHandler(responseWriter http.ResponseWriter, request *http.Request) {
 		// create the target
 		created, err := targetStore.AddTarget(request.Context(), payload.Name, payload.URL)
 		if err != nil {
+			log.Printf("failed to add target: %v", err)
 			http.Error(responseWriter, "failed to create target", http.StatusInternalServerError)
 			return
 		}

--- a/apps/api/store.go
+++ b/apps/api/store.go
@@ -93,6 +93,7 @@ func (inMemoryStore *InMemoryStore) LatestResults(ctx context.Context) ([]model.
 			continue
 		}
 		latestResult := resultsForTarget[len(resultsForTarget)-1]
+		latestResult.Name = inMemoryStore.targets[id].Name
 		latest = append(latest, latestResult)
 	}
 

--- a/deployments/kubernetes/cloudpulse-api-deployment.yaml
+++ b/deployments/kubernetes/cloudpulse-api-deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: cloudpulse # deploys this into the cloudpulse namespace
   labels:
     app: cloudpulse-api # label to identify the deployment to the selector
-spec: # specification of the desired behavior of the deployment
+spec:
+  # specification of the desired behavior of the deployment
   replicas: 2 # number of pod replicas to run at all times
   selector:
     matchLabels:
@@ -15,39 +16,42 @@ spec: # specification of the desired behavior of the deployment
     metadata:
       labels:
         app: cloudpulse-api # label to identify pods created by this deployment. must match the selector above
-    spec: # pod spec: what containers to run and how to run them
+    spec:
+      # pod spec: what containers to run and how to run them
       automountServiceAccountToken: false # disables mounting the default service account token into the pod for security
       containers:
-        - name: api # defines one container named api inside each pod
-          # container image & startup behavior
-          image: cloudpulse-api:dev # uses the cloudpulse-api:dev image built locally by kind
-          imagePullPolicy: IfNotPresent # only pulls the image if it’s not already present on the node
-          # container networking
-          ports:
-            # does not actually open the port or configure the app - purely metadata
-            - containerPort: 8080 # exposes port 8080 INSIDE the container where the api listens
-          env:
-            - name: PORT
-              value: "8080" # sets PORT inside the container to 8080 - tells the application what port to listen on
-          readinessProbe: # check if the container is ready to receive traffic
-            # Kubernetes calls http://pod-ip:8080/health
-            # 200–399 indicates pod is considered ready
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 5 # wait 5 seconds before starting readiness checks
-            periodSeconds: 10 # check every 10 seconds
-          livenessProbe: # configures a liveness probe to check if the container is alive
-            httpGet:
-              path: /health
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 20
-            # resources: CPU & memory guarantees
-          resources:
-            requests:
-              memory: "128Mi" # guarantees min of 128 mebibytes (≈128MB) memory for the container
-              cpu: "100m" # guarantees min of 100 millicores (0.10 cores) CPU for the container
-            limits:
-              memory: "256Mi" # limits max memory to 256 mebibytes (≈256MB) for the container
-              cpu: "500m" # limits max CPU to 500 millicores (0.50 cores) for the container
+      - name: api # defines one container named api inside each pod
+        # container image & startup behavior
+        image: cloudpulse-api:latest # uses the cloudpulse-api:latest image built locally by kind
+        imagePullPolicy: IfNotPresent # only pulls the image if it’s not already present on the node
+        # container networking
+        ports:
+        # does not actually open the port or configure the app - purely metadata
+        - containerPort: 8080 # exposes port 8080 INSIDE the container where the api listens
+        env:
+        - name: PORT
+          value: "8080" # sets PORT inside the container to 8080 - tells the application what port to listen on
+        readinessProbe:
+          # check if the container is ready to receive traffic
+          # Kubernetes calls http://pod-ip:8080/health
+          # 200–399 indicates pod is considered ready
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5 # wait 5 seconds before starting readiness checks
+          periodSeconds: 10 # check every 10 seconds
+        livenessProbe:
+          # configures a liveness probe to check if the container is alive
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          # resources: CPU & memory guarantees
+        resources:
+          requests:
+            memory: "128Mi" # guarantees min of 128 mebibytes (≈128MB) memory for the container
+            cpu: "100m" # guarantees min of 100 millicores (0.10 cores) CPU for the container
+          limits:
+            memory: "256Mi" # limits max memory to 256 mebibytes (≈256MB) for the container
+            cpu: "500m" # limits max CPU to 500 millicores (0.50 cores) for the container

--- a/deployments/kubernetes/dynamodb.yaml
+++ b/deployments/kubernetes/dynamodb.yaml
@@ -1,0 +1,50 @@
+# service: defines a stable network endpoint for the database
+# other pods (API, Runner) can reach it at http://dynamodb-local:8000
+apiVersion: v1
+kind: Service
+metadata:
+  name: dynamodb-local
+  namespace: cloudpulse
+  labels:
+    app: dynamodb-local
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+  selector:
+    app: dynamodb-local
+---
+# deployment: manages the pod(s) that run the actual database container
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dynamodb-local
+  namespace: cloudpulse
+  labels:
+    app: dynamodb-local
+spec:
+  replicas: 1 # only 1 replica because dynamodb local does not support clustering/sharding
+  selector:
+    matchLabels:
+      app: dynamodb-local
+  template:
+    metadata:
+      labels:
+        app: dynamodb-local
+    spec:
+      containers:
+        - name: dynamodb-local
+          image: amazon/dynamodb-local:latest
+          # configuration arguments:
+          #  -sharedDb: uses a single database file for all credentials/clients.
+          #             essential for local dev so the API and Admin CLI see the same tables.
+          #  -inMemory: runs the DB entirely in RAM. fast, but data is lost on pod restart.
+          #             to persist data, remove -inMemory and usage -dbPath with a PersistentVolume.
+          args: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
+          ports:
+            - containerPort: 8000
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/deployments/kubernetes/runner.yaml
+++ b/deployments/kubernetes/runner.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudpulse-runner
+  namespace: cloudpulse
+  labels:
+    app: cloudpulse-runner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudpulse-runner
+  template:
+    metadata:
+      labels:
+        app: cloudpulse-runner
+    spec:
+      containers:
+        - name: runner
+          image: cloudpulse-runner:dev
+          imagePullPolicy: IfNotPresent
+          env:
+            # dynamoDB table names
+            # these must match the names created by the setup-tables-job
+            - name: TABLE_NAME_TARGETS
+              value: "cloudpulse-targets-local"
+            - name: TABLE_NAME_RESULTS
+              value: "cloudpulse-probe-results-local"
+            # AWS_ENDPOINT points to the local DynamoDB Service (dynamodb-local:8000)
+            # this overrides the default AWS region endpoint.
+            - name: AWS_ENDPOINT
+              value: "http://dynamodb-local:8000"
+            - name: AWS_REGION
+              value: "us-east-1"
+            - name: AWS_ACCESS_KEY_ID
+              value: "dummy"
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "dummy"
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"

--- a/deployments/kubernetes/setup-tables-job.yaml
+++ b/deployments/kubernetes/setup-tables-job.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: setup-tables-script
+  namespace: cloudpulse
+data:
+  # The script that initializes the database
+  setup.sh: |
+    #!/bin/sh
+    echo "Waiting for DynamoDB Service..."
+    # 1. Wait loop: Keeps trying to access DynamoDB until it responds.
+    #    This prevents the job from failing immediately if the DB pod is starting up.
+    until aws dynamodb list-tables --endpoint-url http://dynamodb-local:8000 --region us-east-1 > /dev/null 2>&1; do
+      echo "DynamoDB not ready yet..."
+      sleep 2
+    done
+
+    echo "DynamoDB is up. Creating tables..."
+
+    # 2. Create 'targets' table
+    #    ' || true' ensures the script doesn't exit if the table already exists.
+    #    This makes the job idempotent (can be managed/re-run safely).
+    aws dynamodb create-table --endpoint-url http://dynamodb-local:8000 --region us-east-1 \
+      --table-name cloudpulse-targets-local \
+      --attribute-definitions AttributeName=id,AttributeType=S \
+      --key-schema AttributeName=id,KeyType=HASH \
+      --billing-mode PAY_PER_REQUEST || true
+
+    # 3. Create 'results' table
+    aws dynamodb create-table --endpoint-url http://dynamodb-local:8000 --region us-east-1 \
+      --table-name cloudpulse-probe-results-local \
+      --attribute-definitions AttributeName=target_id,AttributeType=S AttributeName=timestamp,AttributeType=N \
+      --key-schema AttributeName=target_id,KeyType=HASH AttributeName=timestamp,KeyType=RANGE \
+      --billing-mode PAY_PER_REQUEST || true
+
+    echo "Tables initialized."
+---
+# Job: Runs a container once to completion
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-tables
+  namespace: cloudpulse
+spec:
+  template:
+    spec:
+      containers:
+        - name: setup-tables
+          image: amazon/aws-cli
+          command: ["/bin/sh", "/scripts/setup.sh"]
+          env:
+            # Dummy credentials are required by the AWS CLI even for local DynamoDB
+            - name: AWS_ACCESS_KEY_ID
+              value: "dummy"
+            - name: AWS_SECRET_ACCESS_KEY
+              value: "dummy"
+            - name: AWS_REGION
+              value: "us-east-1"
+          volumeMounts:
+            - name: script-volume
+              mountPath: /scripts
+      restartPolicy: OnFailure
+      volumes:
+        - name: script-volume
+          configMap:
+            name: setup-tables-script
+            defaultMode: 0755

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,17 @@
-version: '3.8'
-
+# this service runs a local, containerized DynamoDB instance using Amazon’s official DynamoDB Local image.
+# it also includes a setup-tables service that initializes the necessary tables for local development and testing.
+# to use this setup, run `docker-compose up -d` to start the DynamoDB Local service and create the required tables.
 services:
   dynamodb-local:
-    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ."
-    image: "amazon/dynamodb-local:latest"
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ." # starts DynamoDB Local with shared database and persistent storage
+    image: "amazon/dynamodb-local:latest" # runs the in-memory/on-disk local DynamoDB emulator
     container_name: dynamodb-local
     ports:
-      - "8000:8000"
+      - "8000:8000" # maps port 8000 of the container to port 8000 on the host machine
     working_dir: /home/dynamodblocal
 
-  # We can't easily run the API/Runner containerized without extensive init scripts to create tables.
-  # Instead, we will provide the DynamoDB container so the USER can run their go binaries against it.
-  # This setup is much simpler and less error-prone for a quick "test run".
-
   setup-tables:
-    image: amazon/aws-cli
+    image: amazon/aws-cli # uses the AWS CLI image to interact with DynamoDB Local
     depends_on:
       - dynamodb-local
     environment:
@@ -22,7 +19,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=dummy
       - AWS_REGION=us-east-1
       - AWS_DEFAULT_REGION=us-east-1
-    entrypoint: /bin/sh
+    entrypoint: /bin/sh # uses a shell to run multiple commands
     command: >
       -c "
         echo 'Waiting for DynamoDB...';

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -14,6 +14,7 @@ type Target struct {
 // Result represents the outcome of a single uptime probe
 type Result struct {
 	TargetID   string `json:"targetId" dynamodbav:"target_id"`
+	Name       string `json:"name" dynamodbav:"-"`
 	Status     string `json:"status" dynamodbav:"status"`
 	HTTPStatus int    `json:"httpStatus" dynamodbav:"http_status"`
 	Timestamp  int64  `json:"timestamp" dynamodbav:"timestamp"` // added timestamp for history


### PR DESCRIPTION
# Description
This PR enables full local development of the CloudPulse stack on Kubernetes. It introduces the necessary infrastructure manifests for running DynamoDB locally, patches the services to work outside of AWS Lambda/Cloud, and enhances the API response model.

## Changes

### Infrastructure (Kubernetes)
- New Manifests: Added deployments/kubernetes/ manifests for:
  - dynamodb.yaml: Runs DynamoDB Local (Service + Deployment).
  - setup-tables-job.yaml: Initializes targets and results tables on startup.
  - runner.yaml: Deploys the Runner service in local mode.
 
### Service Logic
- Runner: Patched apps/runner/main.go to support a local polling loop when the Lambda runtime environment is not detected.
- DynamoDB Store: Updated internal/store/dynamodb.go to respect the AWS_ENDPOINT environment variable, allowing connection to the local DynamoDB service.

### API Enhancements
- Data Model: Added Name field to the Result struct in internal/model/model.go.
- Results Endpoint: Updated both DynamoDBStore and InMemoryStore to populate the target Name when returning probe results.
- Logging: Added error logging to apps/api/handlers.go for better visibility during target creation failures.

## Verification
Manual Testing:
- Deployed full stack to local K8s cluster.
- Verified DynamoDB tables were created via Job.
- Created target "Google" via API.
- Verified Runner picked up target and recorded healthy results.
- Verified GET /results returns data including the new name field.

## How to Test
### Infrastructure
```bash
kubectl apply -f deployments/kubernetes/dynamodb.yaml -n cloudpulse
kubectl apply -f deployments/kubernetes/setup-tables-job.yaml -n cloudpulse
```
### Deploy Apps
```bash
helm upgrade --install cloudpulse-api deployments/helm/cloudpulse-api -n cloudpulse \
  --set image.tag=v2 \
  --set env.AWS_ENDPOINT="http://dynamodb-local:8000"
kubectl apply -f deployments/kubernetes/runner.yaml -n cloudpulse
```
### Check Results
```bash
kubectl port-forward svc/cloudpulse-api 8080:80 -n cloudpulse
curl http://localhost:8080/results
```